### PR TITLE
Checksum Verification added

### DIFF
--- a/ThemeStore/config.json
+++ b/ThemeStore/config.json
@@ -1,6 +1,6 @@
 
 {
-"label":"Onion OS Theme Store v1.0.4",
+"label":"Onion OS Theme Store v1.0.5",
 "icon":"icon.png",
 "launch":"launch.sh",
 "description":"Previews and downloads of themes"

--- a/ThemeStore/downloadmain.sh
+++ b/ThemeStore/downloadmain.sh
@@ -6,61 +6,110 @@ mkdir /mnt/SDCARD/Themes #just in case it isnt there
 #echo "Running thumbnail script in case there are already previews"
 sleep 5
 #./thumbnails_generator.sh
-echo "Launching downloadmain.sh (preview download script)"
-ping -q -w 1 -c 1 `ip r | grep default | cut -d ' ' -f 3` > /dev/null && echo 'Wifi OK' || echo 'No connection' #mateusza, stackoverflow 100567
-echo "Press X and then menu to skip download"
-echo "Do not cancel on first launch"
-sleep 5
-mkdir logos
-mkdir thumbnails
-#cd /mnt/SDCARD/App/MiyooThemeDownloaderApp/ && rm -f *.png
-#cd /mnt/SDCARD/App/MiyooThemeDownloaderApp/ && rm -f *.zip
-#!/bin/bash
-#cd -
-content=$(wget -qO- https://raw.githubusercontent.com/OnionUI/Themes/main/README.md)
+
+
+echo "Checking for updates"
+
+#This downloads the latest README and grabs its checksum f1c0835b111e94336679169d1e0b2b07 (29-Feb-2024)
+wget -O latest_md https://raw.githubusercontent.com/OnionUI/Themes/main/README.md
+latest_checksum=$(md5sum 'latest_md' | awk '{print $1}')
+#remove the file once md5sum has been calculated
+rm latest_md
+
+#f1c0835b111e94336679169d1e0b2b07
+
+if [ -f "res/current_checksum.txt" ]; then
+    #Checking the checksum of the previous saved checksum
+    current_checksum=$(<"res/current_checksum.txt")
+
+    if [ $current_checksum = $latest_checksum ]; then
+        #There is no changes to the README
+        echo "No Updates Found"
+    else 
+        #There is an update found to the README
+        #Download Themes 
+        echo "Update Found"
+		downloadmain
+
+		#Saves the new checksum to the txt file
+        echo $latest_checksum > res/current_checksum.txt
+    fi 
+else
+
+    echo "First time installation"
+	#Download themes
+    downloadmain
+
+
+	#Saves the new checksum to the txt file
+    echo $latest_checksum > res/current_checksum.txt
+fi
+
+downloadmain(){
+    echo "Launching downloadmain.sh (preview download script)"
+    ping -q -w 1 -c 1 `ip r | grep default | cut -d ' ' -f 3` > /dev/null && echo 'Wifi OK' || echo 'No connection' #mateusza, stackoverflow 100567
+    echo "Press X and then menu to skip download"
+    echo "Do not cancel on first launch"
+    sleep 5
+    mkdir logos
+    mkdir thumbnails
+    #cd /mnt/SDCARD/App/MiyooThemeDownloaderApp/ && rm -f *.png
+    #cd /mnt/SDCARD/App/MiyooThemeDownloaderApp/ && rm -f *.zip
+    #!/bin/bash
+    #cd -
+    content=$(wget -qO- https://raw.githubusercontent.com/OnionUI/Themes/main/README.md)
 
 
 
 
 
-#echo "$content" | grep -o 'icons/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' > preview_urls.txt
+    #echo "$content" | grep -o 'icons/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' > preview_urls.txt
 
-#exit
-#echo "$content" | grep -o 'themes/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' > preview_urls.txt
+    #exit
+    #echo "$content" | grep -o 'themes/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' > preview_urls.txt
 
-#exit
+    #exit
 
 
-echo "$content" | grep -o 'http[s]*://[^"]*preview\.png' | sort | uniq > preview_urls.txt
-echo "$content" | grep -o 'icons/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' >> preview_urls.txt
-#echo "$content" | grep -o 'themes/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' >> preview_urls.txt
-#noecho "$content" | grep -o 'http[s]*://[^"]*\.zip?raw=true' | sort | uniq > zip_urls.txt
-echo "$content" | grep -o 'http[s]*://[^"]*\.zip' | sort | uniq > zip_urls.txt
-echo "$content" | grep -o 'release/[^"]*.zip?raw=true' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' >> zip_urls.txt
-#exit
-echo "Downloading preview images..."
-#nocat preview_urls.txt | xargs -n 1 wget -q
+    echo "$content" | grep -o 'http[s]*://[^"]*preview\.png' | sort | uniq > preview_urls.txt
+    echo "$content" | grep -o 'icons/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' >> preview_urls.txt
+    #echo "$content" | grep -o 'themes/[^"]*gba\.png' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' >> preview_urls.txt
+    #noecho "$content" | grep -o 'http[s]*://[^"]*\.zip?raw=true' | sort | uniq > zip_urls.txt
+    echo "$content" | grep -o 'http[s]*://[^"]*\.zip' | sort | uniq > zip_urls.txt
+    echo "$content" | grep -o 'release/[^"]*.zip?raw=true' | sed 's|^|https://raw.githubusercontent.com/OnionUI/Themes/main/|' >> zip_urls.txt
+    #exit
+    echo "Downloading preview images..."
+    #nocat preview_urls.txt | xargs -n 1 wget -q
 
-amt=$(grep -c '.' preview_urls.txt)
-echo $amt
-LD_LIBRARY_PATH="./imagemagick/libs:$LD_LIBRARY_PATH"
-counter=1
-while [ $counter -le $amt ]; do
-    echo "Iteration $counter"
-    a=$(head -n 1 preview_urls.txt)
-    mkdir "./logos/$counter"
-    wget "$a" -O "./logos/$counter/image1.jpg"
-    ./imagemagick/magick ./logos/$counter/image1.jpg -rotate 180 ./logos/$counter/image1.jpg
+    amt=$(grep -c '.' preview_urls.txt)
+    echo $amt
+    LD_LIBRARY_PATH="./imagemagick/libs:$LD_LIBRARY_PATH"
+    counter=1
+    while [ $counter -le $amt ]; do
+        echo "Iteration $counter"
+        a=$(head -n 1 preview_urls.txt)
+        mkdir "./logos/$counter"
+        wget "$a" -O "./logos/$counter/image1.jpg"
+        ./imagemagick/magick ./logos/$counter/image1.jpg -rotate 180 ./logos/$counter/image1.jpg
 
-    #sleep 1
-    sed -i '1d' preview_urls.txt
-    counter=$((counter + 1))
-done
-echo Making thumbnails for new previews
-sleep 5
-# running thumbnails_generator for AdvanceMenu
-./thumbnails_generator.sh
-#sh launch.sh
-#exit
+        #sleep 1
+        sed -i '1d' preview_urls.txt
+        counter=$((counter + 1))
+    done
+    echo Making thumbnails for new previews
+    sleep 5
+    # running thumbnails_generator for AdvanceMenu
+    ./thumbnails_generator.sh
+    #sh launch.sh
+    #exit
+
+
+}
+
+
+
+
+
+
 
 

--- a/ThemeStore/downloadmain.sh
+++ b/ThemeStore/downloadmain.sh
@@ -8,43 +8,8 @@ sleep 5
 #./thumbnails_generator.sh
 
 
-echo "Checking for updates"
 
-#This downloads the latest README and grabs its checksum f1c0835b111e94336679169d1e0b2b07 (29-Feb-2024)
-wget -O latest_md https://raw.githubusercontent.com/OnionUI/Themes/main/README.md
-latest_checksum=$(md5sum 'latest_md' | awk '{print $1}')
-#remove the file once md5sum has been calculated
-rm latest_md
-
-#f1c0835b111e94336679169d1e0b2b07
-
-if [ -f "res/current_checksum.txt" ]; then
-    #Checking the checksum of the previous saved checksum
-    current_checksum=$(<"res/current_checksum.txt")
-
-    if [ $current_checksum = $latest_checksum ]; then
-        #There is no changes to the README
-        echo "No Updates Found"
-    else 
-        #There is an update found to the README
-        #Download Themes 
-        echo "Update Found"
-		downloadmain
-
-		#Saves the new checksum to the txt file
-        echo $latest_checksum > res/current_checksum.txt
-    fi 
-else
-
-    echo "First time installation"
-	#Download themes
-    downloadmain
-
-
-	#Saves the new checksum to the txt file
-    echo $latest_checksum > res/current_checksum.txt
-fi
-
+#define download function
 downloadmain(){
     echo "Launching downloadmain.sh (preview download script)"
     ping -q -w 1 -c 1 `ip r | grep default | cut -d ' ' -f 3` > /dev/null && echo 'Wifi OK' || echo 'No connection' #mateusza, stackoverflow 100567
@@ -105,6 +70,44 @@ downloadmain(){
 
 
 }
+
+
+echo "Checking for updates"
+
+#This downloads the latest README and grabs its checksum f1c0835b111e94336679169d1e0b2b07 (29-Feb-2024)
+wget -O latest_md https://raw.githubusercontent.com/OnionUI/Themes/main/README.md
+latest_checksum=$(md5sum 'latest_md' | awk '{print $1}')
+#remove the file once md5sum has been calculated
+rm latest_md
+
+#f1c0835b111e94336679169d1e0b2b07
+
+if [ -f "current_checksum.txt" ]; then
+    #Checking the checksum of the previous saved checksum
+    current_checksum=$(<"current_checksum.txt")
+
+    if [ $current_checksum = $latest_checksum ]; then
+        #There is no changes to the README
+        echo "No Updates Found"
+    else 
+        #There is an update found to the README
+        #Download Themes 
+        echo "Update Found"
+		downloadmain
+
+		#Saves the new checksum to the txt file
+        echo $latest_checksum > current_checksum.txt
+    fi 
+else
+
+    echo "First time installation"
+	#Download themes
+    downloadmain
+
+
+	#Saves the new checksum to the txt file
+    echo $latest_checksum > current_checksum.txt
+fi
 
 
 

--- a/ThemeStore/launch.sh
+++ b/ThemeStore/launch.sh
@@ -12,45 +12,12 @@ cd "$progdir"
 touch /tmp/stay_awake
 #Check if a current version of the Theme README has already been downloaded
 #Checking if the file exists 
-echo "Checking for updates"
 
-#This downloads the latest README and grabs its checksum f1c0835b111e94336679169d1e0b2b07 (29-Feb-2024)
-wget -O latest_md https://raw.githubusercontent.com/OnionUI/Themes/main/README.md
-latest_checksum=$(md5sum 'latest_md' | awk '{print $1}')
-#remove the file once md5sum has been calculated
-rm latest_md
-
-#f1c0835b111e94336679169d1e0b2b07
-
-if [ -f "res/current_checksum.txt" ]; then
-    #Checking the checksum of the previous saved checksum
-    current_checksum=$(<"res/current_checksum.txt")
-
-    if [ $current_checksum = $latest_checksum ]; then
-        #There is no changes to the README
-        echo "No Updates Found"
-    else 
-        #There is an update found to the README
-        #Download Themes 
-        echo "Update Found"
-		t -q -e $home"/downloadmain.sh"
-
-		#Saves the new checksum to the txt file
-        echo $latest_checksum > res/current_checksum.txt
-    fi 
-else
-
-    echo "First time installation"
-	#Download themes
-    st -q -e $home"/downloadmain.sh"
-	#Saves the new checksum to the txt file
-    echo $latest_checksum > res/current_checksum.txt
-fi
 #check sum ends
 # running thumbnails_generator for AdvanceMenu
 #./thumbnails_generator.sh
 if [ -f "/mnt/SDCARD/.tmp_update/onionVersion/version.txt" ]; then
-	infoPanel -t "ThemeStore" -m "LOADING...\nMusic : The World Of Douve by DOUVE\nThemeStore by Sebastian Maung\nWith help from schmurtzm" --persistent &
+	infoPanel -t "ThemeStore" -m "LOADING...\nMusic : The World Of Douve by DOUVE\nThemeStore by Sebastian Maung\nWith help from schmurtzm and Lachlan" --persistent &
 	LD_LIBRARY_PATH="./libs:$LD_LIBRARY_PATH"
 else
 	LD_LIBRARY_PATH="./libs:./bin:/customer/lib:/config/lib:/lib"

--- a/ThemeStore/launch.sh
+++ b/ThemeStore/launch.sh
@@ -10,6 +10,7 @@ echo ----
 home="$PWD"
 cd "$progdir"
 touch /tmp/stay_awake
+st -q -e $home"/downloadmain.sh"
 #Check if a current version of the Theme README has already been downloaded
 #Checking if the file exists 
 
@@ -17,7 +18,7 @@ touch /tmp/stay_awake
 # running thumbnails_generator for AdvanceMenu
 #./thumbnails_generator.sh
 if [ -f "/mnt/SDCARD/.tmp_update/onionVersion/version.txt" ]; then
-	infoPanel -t "ThemeStore" -m "LOADING...\nMusic : The World Of Douve by DOUVE\nThemeStore by Sebastian Maung\nWith help from schmurtzm and Lachlan" --persistent &
+	infoPanel -t "ThemeStore" -m "LOADING...\nMusic : The World Of Douve by DOUVE\nThemeStore by Sebastian Maung\nWith help from schmurtzm" --persistent &
 	LD_LIBRARY_PATH="./libs:$LD_LIBRARY_PATH"
 else
 	LD_LIBRARY_PATH="./libs:./bin:/customer/lib:/config/lib:/lib"

--- a/ThemeStore/launch.sh
+++ b/ThemeStore/launch.sh
@@ -10,7 +10,43 @@ echo ----
 home="$PWD"
 cd "$progdir"
 touch /tmp/stay_awake
-st -q -e $home"/downloadmain.sh"
+#Check if a current version of the Theme README has already been downloaded
+#Checking if the file exists 
+echo "Checking for updates"
+
+#This downloads the latest README and grabs its checksum f1c0835b111e94336679169d1e0b2b07 (29-Feb-2024)
+wget -O latest_md https://raw.githubusercontent.com/OnionUI/Themes/main/README.md
+latest_checksum=$(md5sum 'latest_md' | awk '{print $1}')
+#remove the file once md5sum has been calculated
+rm latest_md
+
+#f1c0835b111e94336679169d1e0b2b07
+
+if [ -f "res/current_checksum.txt" ]; then
+    #Checking the checksum of the previous saved checksum
+    current_checksum=$(<"res/current_checksum.txt")
+
+    if [ $current_checksum = $latest_checksum ]; then
+        #There is no changes to the README
+        echo "No Updates Found"
+    else 
+        #There is an update found to the README
+        #Download Themes 
+        echo "Update Found"
+		t -q -e $home"/downloadmain.sh"
+
+		#Saves the new checksum to the txt file
+        echo $latest_checksum > res/current_checksum.txt
+    fi 
+else
+
+    echo "First time installation"
+	#Download themes
+    st -q -e $home"/downloadmain.sh"
+	#Saves the new checksum to the txt file
+    echo $latest_checksum > res/current_checksum.txt
+fi
+#check sum ends
 # running thumbnails_generator for AdvanceMenu
 #./thumbnails_generator.sh
 if [ -f "/mnt/SDCARD/.tmp_update/onionVersion/version.txt" ]; then


### PR DESCRIPTION
Compares a checksum of the current state of the README.md from the Themes Library. 
If a new theme is added to the library, it will generate a new checksum which we can compare to. 
If no updates are found, skips downloading the preview thumbnails and can save a lot of time.